### PR TITLE
[add] #1 Dockerへの移行

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// .devcontainer/devcontainer.json
+{
+    "name": "miakksHP",
+    // 以前作成したDockerfileを参照
+    "build": {
+        "dockerfile": "../Dockerfile",
+        // DockerfileのARGを参照（設定していない場合は省略可能）
+        "args": {
+            "USERNAME": "node"
+        }
+    },
+    // VS Codeが開くディレクトリをコンテナ内の/appに設定
+    "workspaceFolder": "/app",
+    // コンテナ起動後に自動で開きたいポートを設定
+    "forwardPorts": [
+        3000
+    ],
+    // コンテナ内で使用したいVS Code拡張機能を指定
+    "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "vscode-icons-team.vscode-icons",
+        "dsznajder.es7-react-js-snippets",
+        "bradlc.vscode-tailwindcss",
+        "stylelint.vscode-stylelint"
+    ],
+    // 開発中にホストPCのファイルをコンテナにマウントする設定
+    // これにより、ホスト側のVS Codeで編集したコードがコンテナに即座に反映されます。
+    // Dockerfileでインストールされたnode_modulesの上書きを防ぐため、ボリュームマウントを推奨
+    "mounts": [
+        "source=${localWorkspaceFolder},target=/app,type=bind",
+        "source=node_modules_volume-${devcontainerId},target=/app/node_modules,type=volume"
+    ],
+    // コンテナ内でターミナルを開くユーザーを指定
+    "remoteUser": "node"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# .dockerignore
+
+# 依存関係はDockerfile内でインストールするため、含めない
+node_modules
+# Git関連のメタデータ
+.git
+# ローカルキャッシュディレクトリ
+.next
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Dockerfile
+
+# Node.js 22.18.0をベースイメージとして使用
+FROM node:22.18.0
+
+# 作業ディレクトリを /app に設定
+WORKDIR /app
+
+# npmのキャッシュを無効にし、権限設定をnpmの標準ユーザーに設定
+ARG USERNAME=node
+ARG USER_UID=1000
+
+# 依存関係ファイルのみをコピーし、最初にインストール
+COPY package.json package-lock.json ./
+
+# 依存関係をインストール（--legacy-peer-depsを削除）
+RUN npm install
+
+# アプリケーションの残りのコードをコピー
+COPY . .
+
+# Next.jsのデフォルトポート3000を公開
+EXPOSE 3000
+
+# コンテナ起動時のデフォルトコマンド
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
Dockerへの移行を行なった。

実行は
`npm run dev`
## チーム開発におけるDockerとVS Codeの運用
### 1. 最初のセットアップ時（クローン直後）
メンバーがリポジトリをクローンした後、あなたがやったように以下の手順で済みます。

VS Codeでプロジェクトを開く。

「Reopen in Container」をクリックする。

VS CodeがDockerfileとdevcontainer.jsonを読み込み、イメージのビルド、コンテナの起動、VS Codeの接続のすべてを一括で処理します。Docker Hubからイメージをプルするのと同様に、ローカルにイメージがない場合はビルドから行ってくれます。

### 2. 開発の終了時（コンテナの停止）
開発を終える際は、以下のいずれかの操作でコンテナが停止します。

最も簡単な方法: VS Codeのウィンドウを閉じる。

VS Codeは通常、接続していたDev Containerを自動的に停止（またはスリープ状態に移行）します。

手動で停止: VS Codeのコマンドパレットから「Dev Containers: Stop Container」を実行する。

注意点: コンテナが停止しても、データは残るように設計されています。

コンテナ本体: 停止します。CPUやメモリは消費しません。

Docker Desktop (Docker Engine): ホストPC（メンバーのPC）上で起動したままになっていることが多いです。完全に終了したい場合は、タスクトレイやメニューバーからDocker Desktop自体を終了する必要があります。

### 3. 2回目以降の開発開始時
開発を再開する際も、非常に簡単です。

Docker Desktopが起動しているか確認する。 (これがDockerの根幹を動かすサーバーです。もし終了していたら手動で起動する必要があります。)

VS Codeでプロジェクトを開く。

VS Codeの右下のステータスバーにある青いアイコン（< >のようなアイコン）をクリックし、「Dev Containers: Reopen in Container」を選択するか、プロジェクトを開いた際に出るプロンプトに従います。

VS Codeは、停止している既存のコンテナを見つけて、それを**再開（Start）**し、接続してくれます。この際、イメージの再ビルド（時間がかかる処理）は不要です。

まとめると、Docker環境の面倒なライフサイクル管理のほとんどはVS Codeが担ってくれるため、開発者は「コンテナで開く」という操作を意識するだけで開発を始められる、というメリットがあります。