### PR TITLE
[fix]#3 背景追加＋ハニカム型のカードコンポーネント作成

### DIFF
--- a/src/app/(main)/products/descriptions/sustainable_honeybees_park_project_web.tsx
+++ b/src/app/(main)/products/descriptions/sustainable_honeybees_park_project_web.tsx
@@ -11,33 +11,35 @@ type Props = {
 
 export default function SustainableHoneybeesParkProjectWebDescription({ product }: Props) {
     return (
-        <div className="m-auto max-w-7xl p-4 md-p-8">
-            <div className="flex flex-col lg:flex-row items-start justify-center gap-12 lg:min-h-[80vh]">
-                
-                {/* 左カラム：画像ギャラリー */}
-                <div className="w-full lg:w-2/5">
-                    <ImageGallery product={product} />
-                </div>
-
-                {/* 右カラム：プロダクト情報 */}
-                <div className="w-full lg:w-3/5 lg:flex lg:flex-col">
-                    <div>
-                        <ProductHero product={product} />
+        <div className="min-h-screen bg-gradient-to-b from-amber-100 to-[#8BC34A]">
+            <div className="m-auto max-w-7xl p-4 md-p-8">
+                <div className="flex flex-col lg:flex-row items-start justify-center gap-12 lg:min-h-[80vh]">
+                    
+                    {/* 左カラム：画像ギャラリー */}
+                    <div className="w-full lg:w-2/5">
+                        <ImageGallery product={product} />
                     </div>
 
-                    <div className="lg:mt-auto">
-                        <hr className="my-10" />
-                        <h2 className="text-2xl font-bold text-slate-800 mb-6 text-center">プロジェクトの詳細</h2>
-                        
-                        <div className="flex overflow-x-auto hide-scrollbar scroll-px-4">
-                            {(product.description ?? []).map((item) => (
-                                <HoneySentenceCard
-                                    key={item.index}
-                                    index={item.index}
-                                    body={item.body}
-                                    link={item.link}
-                                />
-                            ))}
+                    {/* 右カラム：プロダクト情報 */}
+                    <div className="w-full lg:w-3/5 lg:flex lg:flex-col">
+                        <div>
+                            <ProductHero product={product} />
+                        </div>
+
+                        <div className="lg:mt-auto text-center">
+                            <hr className="my-10" />
+                            <h2 className="text-2xl font-bold text-slate-800 mb-6">プロジェクトの詳細</h2>
+                            
+                            <div className="flex overflow-x-auto hide-scrollbar scroll-px-4">
+                                {(product.description ?? []).map((item) => (
+                                    <HoneySentenceCard
+                                        key={item.index}
+                                        index={item.index}
+                                        body={item.body}
+                                        link={item.link}
+                                    />
+                                ))}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/components/HoneySentenceCard.tsx
+++ b/src/components/HoneySentenceCard.tsx
@@ -20,37 +20,38 @@ export default function HoneySentenceCard({ index, body, link }: Props) {
         <div className="flex-shrink-0 w-[500px] h-[550px] relative group mx-8"> 
             {/* 六角形の背景コンテナ */}
             <div 
-                className="absolute inset-0 bg-amber-100 shadow-lg rounded-lg"
-                style={hexagonStyle}
-            ></div>
-        
-            {/* コンテンツエリア */}
-            <div 
-                className="absolute inset-0 flex flex-col justify-center items-center p-8" 
+                className="relative p-2 w-full h-full bg-amber-200 shadow-lg"
                 style={hexagonStyle}
             >
-                {/* タイトル */}
-                <h3 className="w-full text-center text-lg font-bold text-slate-800 mb-3 h-12 flex items-center justify-center">
-                    {index}
-                </h3>
+        
+                {/* コンテンツエリア */}
+                <div 
+                    className="w-full h-full flex flex-col justify-center items-center p-8 bg-white" 
+                    style={hexagonStyle}
+                >
+                    {/* タイトル */}
+                    <h3 className="w-full text-center text-lg font-bold text-slate-800 mb-3 h-12 flex items-center justify-center">
+                        {index}
+                    </h3>
 
-                {/* 本文 */}
-                <p className="w-full text-center text-sm text-gray-700 whitespace-pre-wrap">
-                    {body}
-                </p>
+                    {/* 本文 */}
+                    <p className="w-full text-center text-sm text-gray-700 whitespace-pre-wrap">
+                        {body}
+                    </p>
 
-                {/* リンク */}
-                {link && (
-                    <div className="w-full text-center mt-4">
-                        <Link 
-                            href={link.url} 
-                            rel="noopener noreferrer"
-                            className="inline-block px-4 py-2 text-slate-800 text-xs font-bold rounded-full hover:bg-amber-500 transition-colors"
-                        >
-                            {link.text}
-                        </Link>
-                    </div>
-                )}
+                    {/* リンク */}
+                    {link && (
+                        <div className="w-full text-center mt-4">
+                            <Link 
+                                href={link.url} 
+                                rel="noopener noreferrer"
+                                className="inline-block px-4 py-2 text-slate-800 text-xs font-bold rounded-full hover:bg-amber-500 transition-colors"
+                            >
+                                {link.text}
+                            </Link>
+                        </div>
+                    )}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #3 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 背景追加を落ち着いた緑に変更
- ハニカム型を修正

<img width="762" height="679" alt="スクリーンショット 2025-10-16 111216" src="https://github.com/user-attachments/assets/7fdfdf98-f95c-4ffa-a6db-493032f56e0f" />

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- なし

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- なし
## 補足

- x